### PR TITLE
Fix typo

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -860,8 +860,7 @@ func (s *BackendImplementation) shouldRetry(err error, req *http.Request, resp *
 
 	stripeErr, _ := err.(*Error)
 
-	// Don't retry if the context was was canceled or its deadline was
-	// exceeded.
+	// Don't retry if the context was canceled or its deadline was exceeded.
 	if req.Context() != nil && req.Context().Err() != nil {
 		switch req.Context().Err() {
 		case context.Canceled:


### PR DESCRIPTION
* "was was" changed to just "was"
* seems like it should fit on one line now